### PR TITLE
chore: Add step to build arm binary and tar.gz

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,8 @@ jobs:
         run: |
           echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
           ARCHIVE=archive-$VERSION.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.$VERSION/$ARCHIVE
+          echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
           pushd archive-$VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,11 +51,13 @@ jobs:
         uses: octokit/request-action@v2.x
         id: get_latest_release
         with:
-          route: GET /repos/momentohq/momento-cli/releases/latest
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: momentohq
+          repo: momento-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run:
-          "echo latest release: ${{ steps.get_latest_release.outputs.data.name }}"
+          "echo latest release: ${{ fromJSON(steps.get_latest_release.outputs.data).name }}"
           #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
           # VERSION=$(echo -n $TAG | cut -c 17-22)
           # ARCHIVE=archive-$VERSION.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,15 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
+      - name: Build aarch64 darwin binary and build tar.gz
+        if: github.event_name == 'pull_request'
+        run: |
+          rustup target add aarch64-apple-darwin
+          RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
+          $REF={{ github.event.pull_request.head.ref }}
+          $VERSION=$(echo -n $REF | tail -c 6)
+          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 
@@ -43,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,17 +62,15 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run:
-          "echo latest release: ${{ fromJSON(steps.get_latest_release.outputs.data).name }}"
-          #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
-          # VERSION=$(echo -n $TAG | cut -c 17-22)
-          # ARCHIVE=archive-$VERSION.tar.gz
-          # LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
-          # curl -LO $LOCATION
-          # tar -zxvf $ARCHIVE
-          # pushd archive-$VERSION
-          #   RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
-          #   tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
-          # popd
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          ARCHIVE=archive-$VERSION.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
+          curl -LO $LOCATION
+          tar -zxvf $ARCHIVE
+          pushd archive-$VERSION
+          RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
+          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          popd
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,12 @@ jobs:
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
 
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+
       - name: Build aarch64 and tar.gz for arm_big_sur
         if: |
           github.event_name == 'pull_request' &&
@@ -72,7 +78,7 @@ jobs:
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           pushd archive-$VERSION
             cargo build --release --target aarch64-apple-darwin
-            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+            tar zcvf ../momento-cli-$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/Cargo.toml"
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**/Cargo.toml"
 jobs:
   test-bot:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           mkdir $ARM_DIR/$VERSION/bin
           pushd archive-$VERSION
             cargo build --release --target aarch64-apple-darwin
-            move  ./target/aarch64-apple-darwin/release/momento ../$ARM_DIR/$VERSION/bin
+            mv  ./target/aarch64-apple-darwin/release/momento ../$ARM_DIR/$VERSION/bin
           popd
           ls $ARM_DIR
           tar zcvf ./momento-cli-$VERSION.arm_big_sur.bottle.tar.gz $ARM_DIR

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: get_latest_release
         with:
-          route: GET /repos/{owner}/{repo}/releases/latest
-          owner: momentohq
-          repo: momento-cli
+          route: GET /repos/momentohq/momento-cli/releases/latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,10 +76,17 @@ jobs:
           matrix.os == 'macos-latest'
         run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          ARM_DIR=momento-cli-$VERSION.arm_big_sur.bottle
+          mkdir $ARM_DIR/$VERSION
+          mv archive-$VERSION/README.md $ARM_DIR/$VERSION
+          mv archive-$VERSION/LICENSE $ARM_DIR/$VERSION
+          mkdir $ARM_DIR/$VERSION/bin
           pushd archive-$VERSION
             cargo build --release --target aarch64-apple-darwin
-            tar zcvf ../momento-cli-$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+            move  ./target/aarch64-apple-darwin/release/momento ../$ARM_DIR/$VERSION/bin
           popd
+          ls $ARM_DIR
+          tar zcvf ./momento-cli-$VERSION.arm_big_sur.bottle.tar.gz $ARM_DIR
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
-        run:
+        run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           ARCHIVE=archive-$VERSION.tar.gz
           LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,11 +65,11 @@ jobs:
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           ARCHIVE=archive-$VERSION.tar.gz
           LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
-          curl -LO $LOCATION
+          curl -OL $LOCATION
           tar -zxvf $ARCHIVE
           pushd archive-$VERSION
-          RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
-          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+            RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
+            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,10 +45,12 @@ jobs:
       - run: brew test-bot --only-tap-syntax
 
       - name: Build aarch64 darwin binary and build tar.gz
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
         run: |
-          REF={{ github.event.pull_request.head.ref }}
-          VERSION=$(echo -n $REF | tail -c 6)
+          TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
+          VERSION=$(echo -n $TAG | cut -c 17-22)
           ARCHIVE=archive-$VERSION.tar.gz
           LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
           curl -LO $LOCATION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
           matrix.os == 'macos-latest'
         run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
-          ARM_DIR=momento-cli-$VERSION.arm_big_sur.bottle
+          ARM_DIR=momento-cli
           mkdir $ARM_DIR
           mkdir $ARM_DIR/$VERSION
           mv archive-$VERSION/README.md $ARM_DIR/$VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,12 @@ jobs:
           matrix.os == 'macos-latest'
         run: |
           echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
-          ARCHIVE=archive-$VERSION.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.$VERSION/$ARCHIVE
+          ARCHIVE=archive-${{ env.$VERSION }}.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.${{ env.$VERSION }}/$ARCHIVE
           echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
-          pushd archive-$VERSION
+          pushd archive-${{ env.$VERSION }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -86,7 +86,7 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          tar zcvf momento-cli${{ env.$VERSION }}.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           repo: momento-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run:
+      - run:
           "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
           #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
           # VERSION=$(echo -n $TAG | cut -c 17-22)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,12 @@ jobs:
           matrix.os == 'macos-latest'
         run: |
           echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
-          ARCHIVE=archive-${{ env.$VERSION }}.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.${{ env.$VERSION }}/$ARCHIVE
+          ARCHIVE=archive-${{ env.VERSION }}.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.${{ env.VERSION }}/$ARCHIVE
           echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
-          pushd archive-${{ env.$VERSION }}
+          pushd archive-${{ env.VERSION }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -86,7 +86,7 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          tar zcvf momento-cli${{ env.$VERSION }}.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          tar zcvf momento-cli${{ env.VERSION }}.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,13 +57,13 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
-          ARCHIVE=archive-${{ env.VERSION }}.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.${{ env.VERSION }}/$ARCHIVE
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          ARCHIVE=archive-$VERSION.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.$VERSION/$ARCHIVE
           echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
-          pushd archive-${{ env.VERSION }}
+          pushd archive-$VERSION
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -86,7 +86,8 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          tar zcvf momento-cli${{ env.VERSION }}.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -42,11 +47,16 @@ jobs:
       - name: Build aarch64 darwin binary and build tar.gz
         if: github.event_name == 'pull_request'
         run: |
-          rustup target add aarch64-apple-darwin
-          RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
-          $REF={{ github.event.pull_request.head.ref }}
-          $VERSION=$(echo -n $REF | tail -c 6)
-          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          REF={{ github.event.pull_request.head.ref }}
+          VERSION=$(echo -n $REF | tail -c 6)
+          ARCHIVE=archive-$VERSION.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
+          curl -LO $LOCATION
+          tar -zxvf $ARCHIVE
+          pushd archive-$VERSION
+            RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
+            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          popd
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,6 @@ jobs:
           echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
-          pushd archive-$VERSION
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -71,23 +70,15 @@ jobs:
           target: aarch64-apple-darwin
           override: true
 
-      - name: Build aarch64
-        if: |
-          github.event_name == 'pull_request' &&
-          matrix.os == 'macos-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --release --target aarch64-apple-darwin
-
-      - name: Build tar.gz for arm_big_sur
+      - name: Build aarch64 and tar.gz for arm_big_sur
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
-          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          pushd archive-$VERSION
+            cargo build --release --target aarch64-apple-darwin
+            VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run:
-          "echo latest release: ${{ steps.get_latest_release.outputs.name }}"
+          "echo latest release: ${{ steps.get_latest_release.outputs.data.name }}"
           #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
           # VERSION=$(echo -n $TAG | cut -c 17-22)
           # ARCHIVE=archive-$VERSION.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           ARCHIVE=archive-$VERSION.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
           pushd archive-$VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           ARM_DIR=momento-cli-$VERSION.arm_big_sur.bottle
+          mkdir $ARM_DIR
           mkdir $ARM_DIR/$VERSION
           mv archive-$VERSION/README.md $ARM_DIR/$VERSION
           mv archive-$VERSION/LICENSE $ARM_DIR/$VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -57,19 +52,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build aarch64 darwin binary and build tar.gz
+      - name: Download archive files
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
+        uses: actions-rs/toolchain@v1
         run: |
-          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
           ARCHIVE=archive-$VERSION.tar.gz
           LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
           pushd archive-$VERSION
-            RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
-            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+
+      - name: Build aarch64
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target aarch64-apple-darwin
+
+      - name: Build tar.gz for arm_big_sur
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        run: |
+          tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 
       - run: brew test-bot --only-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run:
-          "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
+          "echo latest release: ${{ steps.get_latest_release.outputs.name }}"
           #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
           # VERSION=$(echo -n $TAG | cut -c 17-22)
           # ARCHIVE=archive-$VERSION.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,22 +64,14 @@ jobs:
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          override: true
-
       - name: Build aarch64 and tar.gz for arm_big_sur
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
-          ls
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           pushd archive-$VERSION
             cargo build --release --target aarch64-apple-darwin
-            VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
             tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
           popd
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,17 +48,26 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
-        run: |
-          TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
-          VERSION=$(echo -n $TAG | cut -c 17-22)
-          ARCHIVE=archive-$VERSION.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
-          curl -LO $LOCATION
-          tar -zxvf $ARCHIVE
-          pushd archive-$VERSION
-            RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
-            tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
-          popd
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: momentohq
+          repo: momento-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
+          #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
+          # VERSION=$(echo -n $TAG | cut -c 17-22)
+          # ARCHIVE=archive-$VERSION.tar.gz
+          # LOCATION=https://github.com/momentohq/momento-cli/releases/$ARCHIVE
+          # curl -LO $LOCATION
+          # tar -zxvf $ARCHIVE
+          # pushd archive-$VERSION
+          #   RUSTFLAGS="-D warnings" cargo build --release --target aarch64-apple-darwin
+          #   tar zcvf momento-cli$VERSION.arm_big_sur.bottle.tar.gz ./target/aarch64-apple-darwin/release
+          # popd
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,8 @@ jobs:
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
         run: |
+          ls
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           pushd archive-$VERSION
             cargo build --release --target aarch64-apple-darwin
             VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - name: Build aarch64 darwin binary and build tar.gz
+      - name: Get latest release for momento-cli
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
@@ -56,7 +56,12 @@ jobs:
           repo: momento-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run:
+
+      - name: Build aarch64 darwin binary and build tar.gz
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        run:
           "echo latest release: ${{ fromJSON(steps.get_latest_release.outputs.data).name }}"
           #TAG=$(curl -s https://api.github.com/repos/momentohq/momento-cli/releases/latest | grep "tag_name")
           # VERSION=$(echo -n $TAG | cut -c 17-22)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
           ARCHIVE=archive-$VERSION.tar.gz
-          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v.$VERSION/$ARCHIVE
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
           echo $LOCATION
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,6 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           matrix.os == 'macos-latest'
-        uses: actions-rs/toolchain@v1
         run: |
           echo "VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)" >> $GITHUB_ENV
           ARCHIVE=archive-$VERSION.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/Cargo.toml"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**/Cargo.toml"
 jobs:
   test-bot:
     strategy:


### PR DESCRIPTION
Currently, only big_sur and x86_64_linux bottles exist for momento-cli.
This pr adds a step to build arm binary and tar.gz to bottle it up to address [this issue](https://github.com/momentohq/momento-cli/issues/65).