### PR TITLE
Add a MacOS/Arm bottle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,56 +35,55 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      # Commenting out the bottling arm step for now
-      # - name: Get latest release for momento-cli
-      #   if: |
-      #     github.event_name == 'pull_request' &&
-      #     matrix.os == 'macos-latest'
-      #   uses: octokit/request-action@v2.x
-      #   id: get_latest_release
-      #   with:
-      #     route: GET /repos/{owner}/{repo}/releases/latest
-      #     owner: momentohq
-      #     repo: momento-cli
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get latest release for momento-cli
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: momentohq
+          repo: momento-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Download archive files
-      #   if: |
-      #     github.event_name == 'pull_request' &&
-      #     matrix.os == 'macos-latest'
-      #   run: |
-      #     VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
-      #     ARCHIVE=archive-$VERSION.tar.gz
-      #     LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
-      #     echo $LOCATION
-      #     curl -OL $LOCATION
-      #     tar -zxvf $ARCHIVE
+      - name: Download archive files
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        run: |
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          ARCHIVE=archive-$VERSION.tar.gz
+          LOCATION=https://github.com/momentohq/momento-cli/releases/download/v$VERSION/$ARCHIVE
+          echo $LOCATION
+          curl -OL $LOCATION
+          tar -zxvf $ARCHIVE
 
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: stable
-      #     target: aarch64-apple-darwin
-      #     override: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
 
-      # - name: Build aarch64 and tar.gz for arm_big_sur
-      #   if: |
-      #     github.event_name == 'pull_request' &&
-      #     matrix.os == 'macos-latest'
-      #   run: |
-      #     VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
-      #     ARM_DIR=momento-cli
-      #     mkdir $ARM_DIR
-      #     mkdir $ARM_DIR/$VERSION
-      #     mv archive-$VERSION/README.md $ARM_DIR/$VERSION
-      #     mv archive-$VERSION/LICENSE $ARM_DIR/$VERSION
-      #     mkdir $ARM_DIR/$VERSION/bin
-      #     pushd archive-$VERSION
-      #       cargo build --release --target aarch64-apple-darwin
-      #       mv  ./target/aarch64-apple-darwin/release/momento ../$ARM_DIR/$VERSION/bin
-      #     popd
-      #     ls $ARM_DIR
-      #     tar zcvf ./momento-cli-$VERSION.arm_big_sur.bottle.tar.gz $ARM_DIR
+      - name: Build aarch64 and tar.gz for arm_big_sur
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
+        run: |
+          VERSION=$(echo -n ${{ fromJSON(steps.get_latest_release.outputs.data).name }} | tail -c 6)
+          ARM_DIR=momento-cli
+          mkdir $ARM_DIR
+          mkdir $ARM_DIR/$VERSION
+          mv archive-$VERSION/README.md $ARM_DIR/$VERSION
+          mv archive-$VERSION/LICENSE $ARM_DIR/$VERSION
+          mkdir $ARM_DIR/$VERSION/bin
+          pushd archive-$VERSION
+            cargo build --release --target aarch64-apple-darwin
+            mv  ./target/aarch64-apple-darwin/release/momento ../$ARM_DIR/$VERSION/bin
+          popd
+          ls $ARM_DIR
+          tar zcvf ./momento-cli-$VERSION.arm_big_sur.bottle.tar.gz $ARM_DIR
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
@@ -95,6 +94,7 @@ jobs:
         with:
           name: bottles
           path: "*.bottle.*"
+          
   label-pr:
     name: Label pr pr-pull
     needs: test-bot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,17 @@ jobs:
           curl -OL $LOCATION
           tar -zxvf $ARCHIVE
 
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build aarch64 and tar.gz for arm_big_sur
         if: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,9 @@ jobs:
           tar -zxvf $ARCHIVE
 
       - name: Cache Rust dependencies
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
         uses: actions/cache@v3
         with:
           path: |
@@ -72,12 +75,19 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions-rs/toolchain@v1
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
         with:
           toolchain: stable
           target: aarch64-apple-darwin
           override: true
 
+      # Needed by prost-build.
       - name: Install Protoc
+        if: |
+          github.event_name == 'pull_request' &&
+          matrix.os == 'macos-latest'
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,9 @@ jobs:
           target: aarch64-apple-darwin
           override: true
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: Build aarch64 and tar.gz for arm_big_sur
         if: |
           github.event_name == 'pull_request' &&
@@ -89,7 +92,7 @@ jobs:
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
-        if: always() && github.event_name == 'pull_request'
+        if: success() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
           name: bottles


### PR DESCRIPTION
Adds a bottle for MacOS/Arm.

I restored Erika's work. All that was missing is it needs protoc to compile prost-build.

Also
* Cache our Rust deps to try and speed up the build.
* Make sure the MacOS bottle steps are only run for the MacOS matrix (probably a better way to do this).
* Only upload the bottles if we succeed.

Note: This will be easier to read with a split diff.

Closes momentohq/momento-cli/issues/65