### PR TITLE
chore: Add an EditorConfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This normalizes basic whitespace configs across editors, like indentation and trailing whitespace. Most editors use it automatically, others have a plugin.
https://editorconfig.org/