### PR TITLE
chore: Fix the tokens used in our workflows.

### DIFF
--- a/.github/workflows/create_pr_to_update_formula.yml
+++ b/.github/workflows/create_pr_to_update_formula.yml
@@ -22,4 +22,4 @@ jobs:
         pr_label: "automation"
         pr_draft: false
         pr_allow_empty: true
-        github_token: ${{ secrets.PRIVATE_REPO_RELEASE_ACCESS }}
+        github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,4 +105,4 @@ jobs:
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'formula/')
         with:
           labels: pr-pull
-          github_token: ${{ secrets.PRIVATE_REPO_RELEASE_ACCESS }}
+          github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}


### PR DESCRIPTION
secrets.PRIVATE_REPO_RELEASE_ACCESS was removed last month as redundant. https://gomomento.slack.com/archives/C01AC7JT370/p1668715222027629

Without this, "Create PR" always fails.
https://github.com/momentohq/homebrew-tap/actions/runs/3690342451