### PR TITLE
chore: restore uploading artifacts at end of test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,13 @@ jobs:
       - run: brew test-bot --only-formulae --debug
         if: github.event_name == 'pull_request'
 
+      - name: Upload bottles as artifact
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles
+          path: "*.bottle.*"
+
   label-pr:
     name: Label pr pr-pull
     needs: test-bot


### PR DESCRIPTION
When an auto-generated PR comes in from the other repo, after
the test phase runs, the publish phase wants to pull artifacts
off of the github run from the test phase.  In a previous commit
I removed those and that caused the build to fail.  This
attempts to restore them.
