### PR TITLE
fix: actions/upload-artifact@v4 expects unique artifact names per run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         if: success() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles_${{ matrix.os }}
           path: "*.bottle.*"
 
   label-pr:


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1235

Based on the [latest implementation](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tap-new.rb#L136-L141) for the `brew tap-new` command, upgrading to `actions/upload-artifact@v4` also requires ensuring artifact names are distinct within each run since they had made a [breaking change](https://github.com/marketplace/actions/upload-a-build-artifact#breaking-changes).