### PR TITLE
chore: tighten mo formula test to assert the version contract

### DIFF
--- a/Formula/mo.rb.template
+++ b/Formula/mo.rb.template
@@ -29,6 +29,6 @@ class Mo < Formula
   end
 
   test do
-    assert_match "mo", shell_output("#{bin}/mo --version")
+    assert_match(/^mo \d+\.\d+\.\d+/, shell_output("#{bin}/mo --version"))
   end
 end


### PR DESCRIPTION
Tighten the `mo` formula `test do` assertion so it asserts the version contract instead of passing on any output containing "mo".

`assert_match "mo", …` passes on a bare `mo` with no version; `/^mo \d+\.\d+\.\d+/` asserts the `mo X.Y.Z` line `mo --version` prints. Only the test line changes — the template is otherwise unchanged.

Renders per-release into `Formula/mo.rb` via `mfunc-llm-gw`'s `publish-tap.yml`; keeps the in-repo mirror (`homebrew-tap/Formula/mo.rb.template`) and this tap copy byte-identical. Companion to momentohq/mfunc-llm-gw#913 (B172).