### PR TITLE
chore: point mo formula homepage at gomomento.ai

### DIFF
--- a/Formula/mo.rb
+++ b/Formula/mo.rb
@@ -1,6 +1,6 @@
 class Mo < Formula
   desc "Command-line client"
-  homepage "https://www.gomomento.com"
+  homepage "https://gomomento.ai"
 
   bottle do
     root_url "https://github.com/momentohq/homebrew-tap/releases/download/mo-0.67.0"

--- a/Formula/mo.rb.template
+++ b/Formula/mo.rb.template
@@ -1,6 +1,6 @@
 class Mo < Formula
   desc "Command-line client"
-  homepage "https://www.gomomento.com"
+  homepage "https://gomomento.ai"
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
The `mo` CLI's product home is now **gomomento.ai** (post the gomomento.ai domain cutover). Updates `Formula/mo.rb.template` (what `publish-tap` renders from each release) and the current `Formula/mo.rb` homepage `www.gomomento.com` -> `gomomento.ai`. Cosmetic metadata only; no url/sha/version change. Companion to momentohq/mfunc-llm-gw#1560.