### PR TITLE
chore(mo): point formula homepage at gomomento.ai

### DIFF
--- a/Formula/mo.rb
+++ b/Formula/mo.rb
@@ -1,6 +1,6 @@
 class Mo < Formula
   desc "Command-line client"
-  homepage "https://www.gomomento.com"
+  homepage "https://gomomento.ai"
 
   bottle do
     root_url "https://github.com/momentohq/homebrew-tap/releases/download/mo-0.83.1"

--- a/Formula/mo.rb.template
+++ b/Formula/mo.rb.template
@@ -1,6 +1,6 @@
 class Mo < Formula
   desc "Command-line client"
-  homepage "https://www.gomomento.com"
+  homepage "https://gomomento.ai"
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/momento-cli.rb
+++ b/Formula/momento-cli.rb
@@ -1,7 +1,6 @@
 class MomentoCli < Formula
   desc "Cli to interact with Momento services"
   homepage "https://github.com/momentohq/momento-cli"
-  version "0.56.2"
 
   bottle do
     root_url "https://github.com/momentohq/homebrew-tap/releases/download/momento-cli-0.56.2"

--- a/Formula/momento-cli.rb.template
+++ b/Formula/momento-cli.rb.template
@@ -1,7 +1,6 @@
 class MomentoCli < Formula
   desc "Cli to interact with Momento services"
   homepage "https://github.com/momentohq/momento-cli"
-  version "${MOMENTO_CLI_VERSION}"
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Points the `mo` formula homepage (rendered `mo.rb` + `mo.rb.template` that `publish-tap` renders each release) at https://gomomento.ai, the mo marketing site that went live today. The site is CI-deployed from `momentohq/gomomento-ai-site` and verified serving (HTTP 200, valid cert, apex + www).

Part of momentohq/mfunc-llm-gw#1566 (the mfunc reference-copy template PR closes it).
