### PR TITLE
fix: restore version and add audit test

### DIFF
--- a/Formula/momento-cli.rb
+++ b/Formula/momento-cli.rb
@@ -1,6 +1,12 @@
 class MomentoCli < Formula
   desc "Cli to interact with Momento services"
   homepage "https://github.com/momentohq/momento-cli"
+  # Do not remove. The release assets put a "." before the arch triple
+  # (momento-cli-X.Y.Z.aarch64-apple-darwin.tar.gz), which Homebrew's URL version
+  # scanner mis-parses: "X.Y.Z.aarch64" on arm macOS, "86.64" on x86_64 Linux. That
+  # makes brew look for a bottle name that was never published. This is NOT the
+  # redundant-version case brew audit warns about; audit passes with it present.
+  version "0.56.2"
 
   bottle do
     root_url "https://github.com/momentohq/homebrew-tap/releases/download/momento-cli-0.56.2"
@@ -52,5 +58,9 @@ class MomentoCli < Formula
         zsh_completion.install "zsh/_momento"
       end
     end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/momento --version")
   end
 end

--- a/Formula/momento-cli.rb.template
+++ b/Formula/momento-cli.rb.template
@@ -1,6 +1,12 @@
 class MomentoCli < Formula
   desc "Cli to interact with Momento services"
   homepage "https://github.com/momentohq/momento-cli"
+  # Do not remove. The release assets put a "." before the arch triple
+  # (momento-cli-X.Y.Z.aarch64-apple-darwin.tar.gz), which Homebrew's URL version
+  # scanner mis-parses: "X.Y.Z.aarch64" on arm macOS, "86.64" on x86_64 Linux. That
+  # makes brew look for a bottle name that was never published. This is NOT the
+  # redundant-version case brew audit warns about; audit passes with it present.
+  version "${MOMENTO_CLI_VERSION}"
 
   on_macos do
     if Hardware::CPU.intel?
@@ -46,5 +52,9 @@ class MomentoCli < Formula
         zsh_completion.install "zsh/_momento"
       end
     end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/momento --version")
   end
 end


### PR DESCRIPTION
c017fe7 removed `version` from momento-cli.rb and its template on the premise that it was redundant with the version scanned from the URL. It is not. The release assets put a "." before the arch triple, so Homebrew's URL version scanner mis-parses every one of them:

>   momento-cli-0.56.2.aarch64-apple-darwin.tar.gz -> 0.56.2.aarch64
>   momento-cli-0.56.2.x86_64-apple-darwin.tar.gz  -> 0.56.2.x86_64
>   momento-cli-0.56.2.linux_x86_64.tar.gz         -> 86.64
>   momento-cli-0.56.2.linux_aarch64.tar.gz        -> 64

On Apple Silicon that made brew request momento-cli-0.56.2.aarch64.arm64_sequoia.bottle.tar.gz (404) and expect Cellar/momento-cli/0.56.2.aarch64, while the published bottle is momento-cli-0.56.2.arm64_sequoia.bottle.tar.gz unpacking to momento-cli/0.56.2 -- so the install died at the pour step with "Error: No such file or directory". mo is unaffected because its assets use a hyphen before the triple, which scans correctly.

The bottles themselves are fine; their published checksums still match the bottle block, so restoring `version` fixes installs with no rebuild.

Also adds the `test do` block that brew audit was actually asking for.
Verified: `brew audit --strict` and `brew style` were failing on the missing test block both before and after c017fe7 -- dropping `version` fixed no audit problem. Both now exit 0, and the formula resolves to the bottle URL that is actually published.