### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/create_pr_to_update_formula.yml
+++ b/.github/workflows/create_pr_to_update_formula.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate release bot token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+        private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
     - uses: actions/checkout@v4
     
     - name: pull-request
@@ -22,4 +29,4 @@ jobs:
         pr_label: "automation"
         pr_draft: false
         pr_allow_empty: true
-        github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,8 @@ jobs:
           path: "*.bottle.*"
 
   label-pr:
+    permissions:
+      pull-requests: write
     name: Label pr pr-pull
     needs: test-bot
     runs-on: ubuntu-latest
@@ -68,4 +70,4 @@ jobs:
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'formula/')
         with:
           labels: pr-pull
-          github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,15 +59,23 @@ jobs:
           path: "*.bottle.*"
 
   label-pr:
-    permissions:
-      pull-requests: write
     name: Label pr pr-pull
     needs: test-bot
     runs-on: ubuntu-latest
     steps:
+      # publish.yml triggers on `pull_request_target: types: [labeled]` and gates on
+      # this label, and a label applied by GITHUB_TOKEN does not start a workflow run,
+      # so the bottling chain needs an app token here.
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions-ecosystem/action-add-labels@v1
       # Only add this label to branches that update formulae in this repo
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'formula/')
         with:
           labels: pr-pull
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.
- Same-repo work now uses the built-in `GITHUB_TOKEN`, with an explicit
  `permissions:` block wherever it writes. No shared credential involved.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
